### PR TITLE
Move setuptools and pybind11 to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,8 @@ dependencies = [
 Homepage = "https://github.com/valboz/VBBinaryLensing"
 Documentation = "https://www.fisica.unisa.it/gravitationastrophysics/VBBinaryLensing.htm"
 
+[tool.setuptools.packages.find]
+exclude=["tests"]  # FIXME: Remove if you want users use `from VBBinaryLensing import tests`
+
+[tool.setuptools.package-data]
+"VBBinaryLensing.data" = ["*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "pytest",  # FIXME: Testing packages is not usually a dependency unless you
-               #         expect your users to run tests.
+    "pytest",
     "sphinx-astropy",
 ]
 
@@ -34,7 +33,8 @@ Homepage = "https://github.com/valboz/VBBinaryLensing"
 Documentation = "https://www.fisica.unisa.it/gravitationastrophysics/VBBinaryLensing.htm"
 
 [tool.setuptools.packages.find]
-exclude=["tests"]  # FIXME: Remove if you want users use `from VBBinaryLensing import tests`
+where = ["."]
+
 
 [tool.setuptools.package-data]
-"VBBinaryLensing.data" = ["*"]
+"VBBinaryLensing.data" = ["data/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -22,9 +22,8 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "pytest",
-    "pybind11",
-    "setuptools",
+    "pytest",  # FIXME: Testing packages is not usually a dependency unless you
+               #         expect your users to run tests.
     "sphinx-astropy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ version = "3.6.1"
 keywords = ['Microlsening magnification and astrometry']
 authors = [
     { name = "Valerio Bozza", email = "valboz@sa.infn.it" },
+    { name = "Fran Bartolić", email = "fb90@st-andrews.ac.uk" },
+    { name = "Etienne Bachelet", email = "etibachelet@gmail.com" },
 ]
 license = { text = "GPL-3.0" }
 requires-python = ">=3.6,<4"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import Path
 
 import setuptools
 from pybind11.setup_helpers import Pybind11Extension
@@ -9,11 +8,13 @@ from setuptools.command.build_ext import build_ext
 ext_modules = [
     Pybind11Extension(
         # Import package name
-        name="VBBinaryLensing",
+        name="VBBinaryLensing.VBBinaryLensing",
 
         # List of C++ source code
-        # Sort source files for reproducibility
-        sources=sorted(Path("VBBinaryLensing/lib/").glob("*.cpp")),
+        sources=[
+            'VBBinaryLensing/lib/python_bindings.cpp',
+            'VBBinaryLensing/lib/VBBinaryLensingLibrary.cpp'
+        ],
 
         # Path to dir of C++ headers
         include_dirs=["VBBinaryLensing/lib/"],

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,22 @@
-from setuptools import setup, Extension, find_packages
-from setuptools.command.build_ext import build_ext
 import sys
+from pathlib import Path
+
 import setuptools
-import os
-
-__version__ = '3.6.1'
-
-
-class get_pybind_include(object):
-    """Helper class to determine the pybind11 include path
-
-    The purpose of this class is to postpone importing pybind11
-    until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
-
-    def __init__(self, user=False):
-        self.user = user
-
-    def __str__(self):
-        import pybind11
-        return pybind11.get_include(self.user)
-
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import setup
+from setuptools.command.build_ext import build_ext
 
 ext_modules = [
-    Extension(
-        'VBBinaryLensing',
-        ['VBBinaryLensing/lib/python_bindings.cpp', 'VBBinaryLensing/lib/VBBinaryLensingLibrary.cpp'],
-        include_dirs=[
-            # Path to pybind11 headers
-            get_pybind_include(),
-            get_pybind_include(user=True)
-        ],
-        language='c++'
+    Pybind11Extension(
+        # Import package name
+        name="VBBinaryLensing",
+
+        # List of C++ source code
+        # Sort source files for reproducibility
+        sources=sorted(Path("VBBinaryLensing/lib/").glob("*.cpp")),
+
+        # Path to dir of C++ headers
+        include_dirs=["VBBinaryLensing/lib/"],
     ),
 ]
 
@@ -64,8 +49,6 @@ def cpp_flag(compiler):
 
     raise RuntimeError('Unsupported compiler -- at least C++11 support '
                        'is needed!')
-
-
 
 
 class BuildExt(build_ext):
@@ -101,22 +84,6 @@ class BuildExt(build_ext):
         build_ext.build_extensions(self)
 
 setup(
-    name='VBBinaryLensing',
-    version=__version__,
-    author='Valerio Bozza, Fran Bartolic, Etienne Bachelet',
-    author_email='valboz@sa.infn.it, fb90@st-andrews.ac.uk, etibachelet@gmail.com',
-    url='https://github.com/valboz/VBBinaryLensing',
-    description='Python wrapper of the VBBinaryLensing code for \
-            computing microlensing light curves.',
-    long_description='',
     ext_modules=ext_modules,
-    install_requires=['pybind11>=2.3'],
-    setup_requires=['pybind11>=2.3'],
     cmdclass={'build_ext': BuildExt},
-    zip_safe=False,
-    include_package_data=True,
-    packages=['VBBinaryLensing.data'],
-    package_data={'VBBinaryLensing.data': ['data/*',]},
-               
-    
 )


### PR DESCRIPTION
@ebachelet 

- Added pyproject.toml moving all package metadata from `setup.py`
- Replace `setuptools.Extensions` with `pybind11.Pybind11Extension`

**NOTE:** I've set this to merged with the TOML branch and not main.