### PR TITLE
Remove sphinx-astropy from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 dependencies = [
     "numpy",
     "pytest",
-    "sphinx-astropy",
 ]
 
 [project.urls]


### PR DESCRIPTION
Removing sphinx from the `project.dependencies` field in pyproject.toml. This field is only meant for packages need for Python to run VBBinaryLensing.

I don't see Sphinx being used anywhere in this repository. If this project is building documentation, then I can suggest the right place to put Sphinx dependencies.